### PR TITLE
Updates to HTML/CSS structure of 'Add Cover' pages

### DIFF
--- a/views/auth/cover/pages/cover-nlhc-step2.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step2.ejs
@@ -14,74 +14,91 @@
   <% include ../partials/help-button.ejs %>
   <main>
     <div class="container" id="main-content">
-		<h1 class="ico-addcover">Add Cover</h1>
-		<% include ../partials/progress-bar.ejs %>
-		<h2>Non-liability health care</h2>
-		<h3>Are you seeking medical treatment at no cost to you for any of the following mental health conditions?</h3>
+    	<% include ../partials/progress-bar.ejs %>
+		<h1>Add Cover - Non-liability health care</h1>
+		<p>All fields are required unless marked (optional).</p>
+		<fieldset>
+  		<legend>Are you seeking medical treatment at no cost to you for any of the following mental health conditions?</legend>
 		<p>If you have served as a permanent member of the Australian Defence Force you can receive treatment for the mental health conditions listed below at no cost to you. There is no need to establish that these conditions were caused by your service. Select any conditions below that you want cover for.</p>
+       
+    	<p>
+      	<label class="uikit-control-input uikit-control-input--full">
+        	<input class="uikit-control-input__input" type="checkbox" name="hasPTSD" value="on">
+        	<span class="uikit-control-input__text">Post Traumatic Stress Disorder (PTSD)</span>
+      	</label>
+    	</p>
+    	<p>
+      	<label class="uikit-control-input uikit-control-input--full">
+        	<input class="uikit-control-input__input" type="checkbox" name="hasDepressiveDisorder" value="on">
+        	<span class="uikit-control-input__text">Depressive disorder</span>
+      	</label>
+    	</p>
+    	<p>
+		  <label class="uikit-control-input uikit-control-input--full">
+			<input class="uikit-control-input__input" type="checkbox" name="hasAnxietyDisorder" value="on" >
+			<span class="uikit-control-input__text">Anxiety disorder</span>
+		  </label>
+    	</p>
+		<p>
+		  <label class="uikit-control-input uikit-control-input--full">
+			<input class="uikit-control-input__input" type="checkbox" name="hasAlcoholUseDisorder" value="on" >
+			<span class="uikit-control-input__text">Alcohol Use Disorder</span>
+		  </label>
+		</p>
+		<p>
+		  <label class="uikit-control-input uikit-control-input--full">
+			<input class="uikit-control-input__input" type="checkbox" name="hasSubstanceUseDisorder" value="on" >
+			<span class="uikit-control-input__text">Substance Use Disorder</span>
+		  </label>
+		</p>
+		<p>
+		  <label class="uikit-control-input uikit-control-input--full">
+			<input class="uikit-control-input__input" type="checkbox" name="notSeekingNLHCTreatment" value="on" >
+			<span class="uikit-control-input__text">I'm not seeking treatment for any of the above conditions</span>
+		  </label>
+		</p>
+		</fieldset>
+   
+    	<div class="uikit-page-alerts uikit-page-alerts--error" role="alert">
+      	<p>Please choose at least one of the conditions above to continue.</p>
+   		</div>
 
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="hasPTSD" value="on" type="checkbox">
-        <span class="uikit-control-input__text">Post Traumatic Stress Disorder (PTSD)</span>
-      </label>
-    </p>
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="hasDepressiveDisorder" value="on" type="checkbox">
-        <span class="uikit-control-input__text">Depressive disorder</span>
-      </label>
-    </p>
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="hasAnxietyDisorder" value="on" type="checkbox">
-        <span class="uikit-control-input__text">Anxiety disorder</span>
-      </label>
-    </p>
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="hasAlcoholUseDisorder" value="on" type="checkbox">
-        <span class="uikit-control-input__text">Alcohol Use Disorder</span>
-      </label>
-    </p>
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="hasSubstanceUseDisorder" value="on" type="checkbox">
-        <span class="uikit-control-input__text">Substance Use Disorder</span>
-      </label>
-    </p>
-    <p>
-      <label class="uikit-control-input">
-        <input class="uikit-control-input__input" name="notSeekingNLHCTreatment" value="on" type="checkbox">
-        <span class="uikit-control-input__text">I'm not seeking treatment for any of the above conditions</span>
-      </label>
-    </p>
-
-    <div class="uikit-page-alerts uikit-page-alerts--error" role="alert">
-      <p>Please choose at least one of the conditions above to continue.</p>
-    </div>
-
-
-		<div class="pagination">
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Previous</button>
-			<button class="uikit-btn uikit-btn--primary" onclick="window.location.href = '/cover-nlhc-step3-A'">Next</button>
-			<button class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-modal'">Cancel</button>
-		</div>
-
-		<% include ../partials/cancel-modal.ejs %>
-	
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-
-		<script>
-
-		</script>
-
+      	<div class="pagination">
+        	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Previous</button>&nbsp; <a href="#open-modal">Cancel</a>
+        	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-nlhc-step3-A'">Next</button>
+      	</div>
+      
+      <% include ../partials/cancel-modal.ejs %>
+      	
     </div>
   </main>
+  
   <% include ../../../global/partials/footer.ejs %>
   <% include ../partials/panel-help.ejs %>
 
   <script src="/docs/js/jquery-effects.js"></script>
   <script src="/docs/js/main.js"></script>
+  <script>
+    moveProgressBar();
+    // on browser resize...
+    $(window).resize(function() {
+        moveProgressBar();
+    });
+
+    // SIGNATURE PROGRESS
+    function moveProgressBar() {
+      console.log("moveProgressBar");
+        var getPercent = ($('.progress-wrap').data('progress-percent') / 100);
+        var getProgressWrapWidth = $('.progress-wrap').width();
+        var progressTotal = getPercent * getProgressWrapWidth;
+        var animationLength = 2500;
+        
+        // on page load, animate percentage bar to data percentage length
+        // .stop() used to prevent animation queueing
+        $('.progress-bar').stop().animate({
+            left: progressTotal
+        }, animationLength);
+    }
+  </script>
 </body>
 </html>

--- a/views/auth/cover/pages/cover-nlhc-step3-A.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step3-A.ejs
@@ -15,9 +15,8 @@
   <main>
 
     <div class="container" id="main-content">
-		<h1 class="ico-addcover">Add Cover</h1>
-   		<% include ../partials/progress-bar.ejs %>
-   		<h2>Review and submit</h2>
+    	<% include ../partials/progress-bar.ejs %>
+		<h1>Add Cover - Review and submit</h1>
     	<p>You are applying to receive treatment and/or rehabilitation at no cost to you for:</p>
 		<ul>
 		  <li>Depressive disorder</li>
@@ -26,22 +25,43 @@
 		</ul>
 		<p>By clicking on Submit I acknowledge that the information I have provided is truthful and accurate.</p>
 
-		<div class="pagination">
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-nlhc-step2'">Previous</button>
-			<button class="uikit-btn uikit-btn--primary" onclick="window.location.href = '/cover-nlhc-step4-A'">Submit</button>
-			<button class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-modal'">Cancel</button>
-		</div>
-
-		<% include ../partials/cancel-modal.ejs %>
-
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+      	<div class="pagination">
+        	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-nlhc-step2'">Previous</button>&nbsp; <a href="#open-modal">Cancel</a>
+        	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-nlhc-step4-A'">Submit</button>
+      	</div>
+      
+      <% include ../partials/cancel-modal.ejs %>
 
     </div>
   </main>
+
   <% include ../../../global/partials/footer.ejs %>
   <% include ../partials/panel-help.ejs %>
 
   <script src="/docs/js/jquery-effects.js"></script>
   <script src="/docs/js/main.js"></script>
+  <script>
+    moveProgressBar();
+    // on browser resize...
+    $(window).resize(function() {
+        moveProgressBar();
+    });
+
+    // SIGNATURE PROGRESS
+    function moveProgressBar() {
+      console.log("moveProgressBar");
+        var getPercent = ($('.progress-wrap').data('progress-percent') / 100);
+        var getProgressWrapWidth = $('.progress-wrap').width();
+        var progressTotal = getPercent * getProgressWrapWidth;
+        var animationLength = 2500;
+        
+        // on page load, animate percentage bar to data percentage length
+        // .stop() used to prevent animation queueing
+        $('.progress-bar').stop().animate({
+            left: progressTotal
+        }, animationLength);
+    }
+  </script>
+  
 </body>
 </html>

--- a/views/auth/cover/pages/cover-nlhc-step3-B.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step3-B.ejs
@@ -15,30 +15,49 @@
   <main>
 
     <div class="container" id="main-content">
-    	<h1 class="ico-addcover">Add Cover</h1>
     	<% include ../partials/progress-bar.ejs %>
-		<h2>Please visit a GP to get a medical diagnosis for your injury and condition</h2>
-
-    <div class="uikit-page-alerts uikit-page-alerts--warning" role="alert">
-      <h3>Visit your GP</h3>
-      <p>To apply for cover we need a medical diagnosis from a GP. Please download and print the medical diagnosis form and take this to your GP for them to complete and sign.</p>
-      <button class="uikit-btn uikit-btn--primary" onclick="">Download medical diagnosis form</button>
-    </div>
-
-
-		<div class="pagination">
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-nlhc-step2'">Previous</button>
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/landing'">Back to Home</button>
+    	<h1>Add Cover - Diagnosis required</h1>
+    	
+		<div class="uikit-page-alerts uikit-page-alerts--warning" role="alert">
+		  <h3>Visit your GP</h3>
+		  <p>To apply for cover we need a medical diagnosis from a GP. Please download and print the medical diagnosis form and take this to your GP for them to complete and sign.</p>
+		  <button class="uikit-btn uikit-btn--primary" onclick="">Download medical diagnosis form</button>
 		</div>
 
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+      	<div class="pagination">
+        	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-nlhc-step2'">Previous</button>
+        	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Back to home</button>
+      	</div>
 
     </div>
   </main>
+  
   <% include ../../../global/partials/footer.ejs %>
   <% include ../partials/panel-help.ejs %>
 
   <script src="/docs/js/jquery-effects.js"></script>
   <script src="/docs/js/main.js"></script>
+  <script>
+    moveProgressBar();
+    // on browser resize...
+    $(window).resize(function() {
+        moveProgressBar();
+    });
+
+    // SIGNATURE PROGRESS
+    function moveProgressBar() {
+      console.log("moveProgressBar");
+        var getPercent = ($('.progress-wrap').data('progress-percent') / 100);
+        var getProgressWrapWidth = $('.progress-wrap').width();
+        var progressTotal = getPercent * getProgressWrapWidth;
+        var animationLength = 2500;
+        
+        // on page load, animate percentage bar to data percentage length
+        // .stop() used to prevent animation queueing
+        $('.progress-bar').stop().animate({
+            left: progressTotal
+        }, animationLength);
+    }
+  </script>
 </body>
 </html>

--- a/views/auth/cover/pages/cover-nlhc-step4-A.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step4-A.ejs
@@ -15,9 +15,10 @@
   <main>
 
     <div class="container" id="main-content">
-		<h1 class="ico-addcover">Add Cover</h1>
-   		<% include ../partials/progress-bar.ejs %>
-   		<h2>Success! Your request for cover has been received.</h2>
+    	<% include ../partials/progress-bar.ejs %>
+		<h1>Add Cover - Success!</h1>
+   		
+		<h3>Your request for cover has been received.</h3>
     	<p>Once it is processed you will be able to receive treatment at no cost to you for the following conditions:</p>
 		<ul>
 		  <li>Depressive disorder</li>
@@ -32,12 +33,9 @@
 		  <button class="uikit-btn uikit-btn--primary" onclick="">Download medical diagnosis form</button>
 		</div>
 
-
-		<div class="pagination">
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Back to Home</button>
-		</div>
-
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+      <div class="pagination">
+        <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Back to home</button>
+      </div>
 
     </div>
   </main>
@@ -46,5 +44,27 @@
 
   <script src="/docs/js/jquery-effects.js"></script>
   <script src="/docs/js/main.js"></script>
+  <script>
+    moveProgressBar();
+    // on browser resize...
+    $(window).resize(function() {
+        moveProgressBar();
+    });
+
+    // SIGNATURE PROGRESS
+    function moveProgressBar() {
+      console.log("moveProgressBar");
+        var getPercent = ($('.progress-wrap').data('progress-percent') / 100);
+        var getProgressWrapWidth = $('.progress-wrap').width();
+        var progressTotal = getPercent * getProgressWrapWidth;
+        var animationLength = 2500;
+        
+        // on page load, animate percentage bar to data percentage length
+        // .stop() used to prevent animation queueing
+        $('.progress-bar').stop().animate({
+            left: progressTotal
+        }, animationLength);
+    }
+  </script>
 </body>
 </html>

--- a/views/auth/cover/pages/cover-step2.ejs
+++ b/views/auth/cover/pages/cover-step2.ejs
@@ -11,14 +11,15 @@
   <nav class="uikit-skip-link"><a class="uikit-skip-link__link" href="#main-content">Skip to main content</a></nav>
   <% include ../../../global/partials/header-version.ejs %>
   <% include ../../header-authenticated.ejs %>
-  <% include ../partials/progress-bar.ejs %>
+  <% include ../partials/help-button.ejs %>
   <main>
 
     <div class="container" id="main-content">
-		<h1>Diagnosis <span>(Step 2 of 4)</span></h1>
+    	<% include ../partials/progress-bar.ejs %>
+		<h1>Add Cover - Diagnosis</h1>
 		
-		<h3>What have you been medically diagnosed with?</h3>
-		
+		<fieldset>
+  		<legend>What have you been medically diagnosed with?</legend>
 		<p>Enter the term provided by your GP or Specialist used to describe the condition. <br />
 		<em>Example: 'Acute meniscal tear of the knee'</em>.</p>
 		
@@ -38,7 +39,6 @@
 		
 		<div class="row">
 		<div class="col-sm-12">
-
 		<div class="info-box uploads">
 			<h4>Upload your GP or Specialist's medical report</h4>
 			<p>Providing supporting documents is optional but may help us assess your request for cover. Supporting documents may include:</p>
@@ -61,27 +61,46 @@
 					<td class="centred"><button class="uikit-btn uikit-btn--tertiary small btnDelete">Delete</button></td>
 				</tr>
 			</table>
+		
 		</div>
-
 		</div></div>
+		</fieldset>
 		
 		<div class="pagination">
-			<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Previous</button>
-			<button class="uikit-btn uikit-btn--tertiary btnExit">Save and exit</button>
-			<button class="uikit-btn floated btnNext">Save and next</button>
-		</div>
-
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-
-		<script>
-			$( ".btnUpload" ).click(function() {
-				$( ".document-uploads" ).toggle("fast");
-				$( ".no-path" ).hide();
-			});
-		</script>
+        	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Previous</button>&nbsp; <a href="#open-modal">Cancel</a>
+        	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step3'">Next</button>
+      	</div>
+      
+        <% include ../partials/cancel-modal.ejs %>
    
     </div>
   </main>
   <% include ../../../global/partials/footer.ejs %>
+  <% include ../partials/panel-help.ejs %>
+			
+  <script src="/docs/js/jquery-effects.js"></script>
+  <script src="/docs/js/main.js"></script>
+  <script>
+    moveProgressBar();
+    // on browser resize...
+    $(window).resize(function() {
+        moveProgressBar();
+    });
+
+    // SIGNATURE PROGRESS
+    function moveProgressBar() {
+      console.log("moveProgressBar");
+        var getPercent = ($('.progress-wrap').data('progress-percent') / 100);
+        var getProgressWrapWidth = $('.progress-wrap').width();
+        var progressTotal = getPercent * getProgressWrapWidth;
+        var animationLength = 2500;
+        
+        // on page load, animate percentage bar to data percentage length
+        // .stop() used to prevent animation queueing
+        $('.progress-bar').stop().animate({
+            left: progressTotal
+        }, animationLength);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Includes
- moving the progress-bar partial above <h1>

- changes to <h1> markup, adding a paragraph about required fields

- moving to <fieldset> and <legend> instead of <h3>

- changes to the 'Previous', 'Cancel' and 'Next' buttons

- added a cancel-modal partial; and

- added a panel-help partial with accompanying <script> code.