### PR TITLE
Put the day input back in and changed the hint text from 'Approximate…

### DIFF
--- a/views/auth/cover/pages/cover-step2.ejs
+++ b/views/auth/cover/pages/cover-step2.ejs
@@ -30,7 +30,8 @@
     <fieldset>
       <legend>Approximately when did it happen, or when did it start happening?</legend>
       <div class="form-group">
-        <label class="uikit-text-input__label" for="dd"><span class="hint">Approximate MM / YYYY</span></label>
+        <label class="uikit-text-input__label" for="dd"><span class="hint">If you do not know the date, enter the approximate month and year – MM / YYYY</span></label>
+        <input class="uikit-text-input dd" type="text" name="dd" id="dd" maxlength="2" required aria-required="true" aria-label="2 digit day"> /
         <input class="uikit-text-input mm" type="text" name="mm" id="mm" maxlength="2" required aria-required="true" aria-label="2 digit month"> /
         <input class="uikit-text-input yyyy" type="text" name="yyyy" id="yyyy" maxlength="4" required aria-required="true" aria-label="4 digit year">
       </div>


### PR DESCRIPTION
… MM / YYYY' to 'If you do not know the date, enter the approximate month and year – MM / YYYY'