### PR TITLE
MYS-315 accessibility fixes:

### DIFF
--- a/views/auth/cover/pages/cover-nlhc-step2.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step2.ejs
@@ -33,11 +33,9 @@
       	<div class="pagination">
         	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'">Previous</button>&nbsp;
 			    <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+          <% include ../partials/cancel-modal.ejs %>
         	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-nlhc-approved">Next</button>
       	</div>
-
-      <% include ../partials/cancel-modal.ejs %>
-
     </div>
   </main>
 

--- a/views/auth/cover/pages/cover-nlhc-step4.ejs
+++ b/views/auth/cover/pages/cover-nlhc-step4.ejs
@@ -42,7 +42,10 @@
   <% include ../partials/panel-help.ejs %>
 
   <script>
-    document.getElementById("percentage").style.width = "100%";
+    var percentage = document.getElementById("percentage");
+    if (percentage != null) {
+      percentage.style.width = "100%";
+    }
   </script>
 </body>
 </html>

--- a/views/auth/cover/pages/cover-step1.ejs
+++ b/views/auth/cover/pages/cover-step1.ejs
@@ -30,10 +30,10 @@
 
       <div class="pagination">
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Back to home</button>
-        <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'">Cancel</a>
+        <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'">Cancel</button>
+        <% include ../partials/cancel-modal.ejs %>
         <button class="uikit-btn floated btnNext">Next</button>
       </div>
-      <% include ../partials/cancel-modal.ejs %>
     </div>
   </main>
 

--- a/views/auth/cover/pages/cover-step2.ejs
+++ b/views/auth/cover/pages/cover-step2.ejs
@@ -61,17 +61,16 @@
             <td class="centred"><a href="#open-removefile-modal" class="uikit-btn uikit-btn--tertiary small btnDelete" title="Remove this document from your request for cover" id="coverRemoveFileBtn">Remove</a></td>
           </tr>
         </table>
+        <% include ../partials/removefile-modal.ejs %>
       </fieldset>
 
 		  <div class="pagination">
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step1'" title="Go to the previous Add Cover page">Previous</button>&nbsp;
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Save and exit</button>&nbsp;
 			  <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+        <% include ../partials/cancel-modal.ejs %>
         <button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step3'" title="Save and go to the next Add Cover page">Save and next</button>
       </div>
-
-      <% include ../partials/removefile-modal.ejs %>
-      <% include ../partials/cancel-modal.ejs %>
 
     </div>
   </main>

--- a/views/auth/cover/pages/cover-step3-sop.ejs
+++ b/views/auth/cover/pages/cover-step3-sop.ejs
@@ -72,21 +72,19 @@
           </tr>
           <tr>
             <td>GP-Report-20170601.doc</td>
-            <td class="centred"><a href="#open-removeSupporingFile-modal" class="uikit-btn uikit-btn--tertiary small btnDelete" title="Remove this document from your request for cover">Remove</a></td>
+            <td class="centred"><a href="#open-removeSupportingFile-modal" class="uikit-btn uikit-btn--tertiary small btnDelete" title="Remove this document from your request for cover" id="coverRemoveFileBtn">Remove</a></td>
           </tr>
         </table>
+        <% include ../partials/removeSupportingFile-modal.ejs %>
       </fieldset>
 
 		  <div class="pagination">
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step2'" title="Go to the previous Add Cover page">Previous</button>&nbsp;
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Save and exit</button>&nbsp;
 			  <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+        <% include ../partials/cancel-modal.ejs %>
         <button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step4'" title="Save and go to the next Add Cover page">Save and next</button>
       </div>
-
-      <% include ../partials/removeSupportingFile-modal.ejs %>
-      <% include ../partials/cancel-modal.ejs %>
-
     </div>
   </main>
 

--- a/views/auth/cover/pages/cover-step3.ejs
+++ b/views/auth/cover/pages/cover-step3.ejs
@@ -49,18 +49,16 @@
             <td class="centred"><a href="#open-removeSupportingFile-modal" class="uikit-btn uikit-btn--tertiary small btnDelete" title="Remove this document from your request for cover" id="coverRemoveFileBtn">Remove</a></td>
           </tr>
         </table>
+        <% include ../partials/removeSupportingFile-modal.ejs %>
       </fieldset>
 
 		  <div class="pagination">
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step2'" title="Go to the previous Add Cover page">Previous</button>&nbsp;
         <button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Save and exit</button>&nbsp;
 			  <button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+        <% include ../partials/cancel-modal.ejs %>
         <button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step4'" title="Save and go to the next Add Cover page">Save and next</button>
       </div>
-
-      <% include ../partials/removeSupportingFile-modal.ejs %>
-      <% include ../partials/cancel-modal.ejs %>
-
     </div>
   </main>
   <% include ../../../global/partials/footer.ejs %>

--- a/views/auth/cover/pages/cover-step4.ejs
+++ b/views/auth/cover/pages/cover-step4.ejs
@@ -209,13 +209,9 @@
       	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step3'" title="Go to the previous Add Cover page">Previous</button>&nbsp;
       	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Save and exit</button>&nbsp;
       	<button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+        <% include ../partials/cancel-modal.ejs %>
       	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step5'" title="Save and go to the next Add Cover page">Save and next</button>
     	</div>
-
-      <% include ../partials/removefile-modal.ejs %>
-      <% include ../partials/cancel-modal.ejs %>
-
-
   </main>
 
   <% include ../../../global/partials/footer.ejs %>

--- a/views/auth/cover/pages/cover-step5.ejs
+++ b/views/auth/cover/pages/cover-step5.ejs
@@ -108,12 +108,9 @@
         	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/cover-step4'" title="Go to the previous Add Cover page">Previous</button>&nbsp;
         	<button class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '/auth'">Save and exit</button>&nbsp;
         	<button id="coverCancelBtn" class="uikit-btn uikit-btn--borderless" onclick="window.location.href = '#open-cancel-modal'" title="Cancel the request for cover">Cancel</button>&nbsp;
+          <% include ../partials/cancel-modal.ejs %>
         	<button class="uikit-btn floated btnNext" onclick="window.location.href = '/cover-step6'" title="Go to the next Add Cover page">Submit request for cover</button>
       	</div>
-
-        <% include ../partials/removefile-modal.ejs %>
-        <% include ../partials/cancel-modal.ejs %>
-
     </div>
   </main>
   <% include ../../../global/partials/footer.ejs %>

--- a/views/auth/cover/partials/cancel-modal.ejs
+++ b/views/auth/cover/partials/cancel-modal.ejs
@@ -1,11 +1,11 @@
 <div role="dialog" aria-hidden="true" aria-labelledby="cancelModalTitle" aria-describedby="cancelModalDesc" id="open-cancel-modal" class="modal-window">
 	<div role="document">
-		<a href="#" title="Close" class="modal-close" id="cancelModalCloseBtn">Close</a>
+		<a href="#close-modal" title="Close" class="modal-close" id="cancelModalCloseBtn">Close</a>
 		<h1 id="cancelModalTitle">Do you want to cancel?</h1>
 		<p id="cancelModalDesc">This will delete your claim and you will need to start over.</p>
 		<div class="modal-buttons">
 			<button id="cancelModalYesBtn" class="uikit-btn" onclick="window.location.href = '/auth'">Yes</button>
-			<button id="cancelModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#'">No</button>
+			<button id="cancelModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#close-modal'">No</button>
 		</div>
 	</div>
 </div>

--- a/views/auth/cover/partials/modal-common.ejs
+++ b/views/auth/cover/partials/modal-common.ejs
@@ -22,28 +22,32 @@
 		// defining this variable unset until modal is opened (so that callback functions can see it)
 		var previousClickableElement = null;
 
-		// Reusable functions for the modal
+		// Reusable functions for the modal (using runtime-defined functions to avoid definition order issues)
 
 		// Will return -1 if the currently focused item ID isn't on the focusItems list.
 		// This will ensure elements stay on the loop.
-		function getFocusedItemIndex() {
-			var curFocusedItem = $(":focus");
+		var getFocusedItemIndex = function(currItem) {
+			var curFocusedItem = (currItem == null) ? $(document.activeElement) : currItem;
 			return focusItems.indexOf(curFocusedItem.attr('id'));
+		};
+
+		var handleBlurOnOpenModal = function() {
+			if (getFocusedItemIndex() == -1) {
+				doDefaultFocusItem();
+			}
 		}
 
 		// Workaround handler where default focus is NOT on the modal for whatever reason
-		function handleGlobalKbd(evt) {
+		var handleGlobalKbd = function(evt) {
 			if (modalIsOpen == true) {
 				if (evt.key == 'Escape') {
 					handleEscape(evt);
 				} else if (evt.key == 'Tab') {
 					// after processing everything, check that current focused item is
 					// not within modal.
-					setTimeout(function() {
-						if (getFocusedItemIndex() == -1) {
-							doDefaultFocusItem();
-						}
-					}, 25);
+					if (getFocusedItemIndex($(document.activeElement).next()) == -1) {
+						doDefaultFocusItem();
+					}
 				}
 			} else {
 				// remove this binding where it isn't open (shouldn't happen but just in case.)
@@ -51,8 +55,20 @@
 			}
 		};
 
+		var handleBrowserFocusIn = function(evt) {
+			if (modalIsOpen) {
+				if (getFocusedItemIndex($(evt.target)) == -1) {
+					console.log('boom');
+					doDefaultFocusItem();
+					evt.stopPropagation();
+				}
+			} else {
+				$(window).unbind('focus', handleBrowserFocusIn);
+			}
+		}
+
 		// Default focus action
-		function doDefaultFocusItem() {
+		var doDefaultFocusItem = function() {
 			// ideally we want to focus on title but tabindex is apparently bad practice. see:
 			// https://stackoverflow.com/questions/40128504/nvda-screen-reader-reads-clickable-word-on-text
 			//var defaultItem = $("#"+modalElementPrefix+"Title");
@@ -60,18 +76,18 @@
 
 			var defaultItem = $("#"+modalElementPrefix+"CloseBtn");
 			setTimeout(function() { defaultItem.focus(); }, 25);
-		}
+		};
 
 		// Action to trigger when escape key is used.
-		function handleEscape(evt) {
+		var handleEscape = function(evt) {
 			setTimeout(function() {
 				$("#"+modalElementPrefix+"CloseBtn").click();
 			});
 			evt.stopPropagation();
-		}
+		};
 
 		// Handler that executes whenever the modal appears.
-		function enableModal(evt, previousButton) {
+		var enableModal = function(evt, previousButton) {
 			// Will default to a given input trigger's ID name before
 			// showing the modal.
 			previousClickableElement = (previousButton == null)
@@ -81,24 +97,31 @@
 			// Unhide the modal context according to ARIA.
 			$("#"+modalName).attr('aria-hidden', false);
 
+			// Needed to handle ESC key in edge cases where the modal is not focused.
 			modalIsOpen = true;
+			$(document).keydown(handleGlobalKbd);
 
-			// jQuery sometimes didn't trigger focus immediately, so this was done.
-			//setTimeout(function() {$("#"+modalElementPrefix+"CloseBtn").focus();});
-			setTimeout(doDefaultFocusItem);
+			// Needed in case tab selection from browser window to document
+			// starts going through the DOM with the modal open.
+			$(window).focus(handleBrowserFocusIn);
+
+			doDefaultFocusItem();
 
 			// disable body scroll bar.
 			$("body").css('overflow', 'hidden');
-		}
+		};
 
-		function closeModal(evt) {
-			// jQuery seems to be unreliable with manual event invocations.
+		var closeModal = function(evt) {
+			window.location.href = '#close-modal';
+
+			// restore focus on last selected element before showing modal.
 			setTimeout(function() {
-				// force UIKIT to hide the modal by omitting its fragment.
-				window.location.href = '#';
+				// test if browser successfully goes back to the trigger by default
+				// else focus manually.
 
-				// restore focus on last selected element before showing modal.
-				setTimeout(function() { previousClickableElement.focus(); });
+				if (previousClickableElement[0] != document.activeElement) {
+					previousClickableElement.focus();
+				}
 			});
 
 			// Remove workaround binding for background close modal.
@@ -111,31 +134,36 @@
 			// re-enables body scroll bar
 			$("body").css('overflow', 'auto');
 			evt.preventDefault();
-		}
+		};
+
+		var focusOnFirstModalItem = function() {
+			$("#"+focusItems[0]).focus();
+		};
+
+		var focusOnLastModalItem = function() {
+			$("#"+focusItems[focusItems.length - 1]).focus();
+		};
 
 		// Logic for enforcing modal loop to prevent background tabbing.
-		function loopTabWhenOpen(evt) {
+		var loopTabWhenOpen = function(evt) {
 			var focusItemIndex = getFocusedItemIndex();
 
 			if (evt.shiftKey) {
 				// Back tab nav
-				if (focusItemIndex < 0) {
+				if (focusItemIndex == 0 || focusItemIndex == -1) {
 					$("#" + focusItems[(focusItems.length - 1)]).focus();
 					evt.preventDefault();
 				}
 			} else {
 				// Forward tab nav
-				if (focusItemIndex == (focusItems.length) || focusItemIndex == -1) {
+				if (focusItemIndex == (focusItems.length - 1) || focusItemIndex == -1) {
 					$("#" + focusItems[0]).focus();
 					evt.preventDefault();
 				}
 			}
-		}
+		};
 
 		// Javascript/jQuery stuff happens below from here.
-
-		// Needed to handle ESC key in edge cases where the modal is not focused.
-		$(document).keydown(handleGlobalKbd);
 
 		// While UIKIT has its own behaviour for the modal style based on URL fragment,
 		// this is so that the JS accessibility/usability logic on this script is used.
@@ -158,27 +186,39 @@
 
 		// Keyboard hooks for supporting
 		$("#"+modalName).keydown(function(evt) {
-			switch (evt.key) {
-				case "Escape": handleEscape(evt);
+			switch (evt.key.toLowerCase()) {
+				case "esc": // IE uses this key name
+				case "escape": handleEscape(evt);
 					break;
 
-				// guarantee that the focus behaviour is triggered before handling.
-				case "Tab": setTimeout(function() { loopTabWhenOpen(evt); });
+				// tab focus handling
+				case "tab": loopTabWhenOpen(evt);
 					break;
 				// force click event for current focused element
-				case "Enter":
+				case "enter":
 					setTimeout(function() { $(evt.target).click();});
 					break;
-				case "ArrowUp":
-				case "ArrowDown":
-				case "ArrowLeft":
-				case "ArrowRight":
-					// in case NVDA or another screen reader goes beyond the loop
-					// when hooking arrow input behaviour to choose next input element.
+
+				// in case NVDA or another screen reader goes beyond the loop
+				// when hooking arrow input behaviour to choose next input element.
+				case "arrowup":
+				case "arrowleft":
 					var focusedItemIndex = getFocusedItemIndex();
 					if (focusedItemIndex == -1) {
 						// in those cases, just force it to the close button.
-						$("#"+modalElementPrefix+"CloseBtn").focus();
+						focusOnFirstModalItem();
+						evt.stopPropagation();
+					}
+
+					// else use default browser behaviour in this instance.
+					break;
+
+				case "arrowdown":
+				case "arrowright":
+					var focusedItemIndex = getFocusedItemIndex();
+					if (focusedItemIndex == -1) {
+						// in those cases, just force it to the close button.
+						focusOnLastModalItem();
 						evt.stopPropagation();
 					}
 
@@ -186,6 +226,8 @@
 					break;
 			}
 		});
+
+		$("#"+modalName).blur(handleBlurOnOpenModal);
 
 		// For prototype purposes - where modal is opened by URL fragment,
 		// ensure script is ready to handle this too.

--- a/views/auth/cover/partials/removeSupportingFile-modal.ejs
+++ b/views/auth/cover/partials/removeSupportingFile-modal.ejs
@@ -1,11 +1,11 @@
 <div role="dialog" aria-hidden="true" aria-labelledby="removeSupportingFileModalTitle" aria-describedby="removeSupportingFileModalDesc" id="open-removeSupportingFile-modal" class="modal-window">
 	<div role="document">
-		<a href="#" title="Close" class="modal-close" id="removeSupportingFileModalCloseBtn">Close</a>
+		<a href="#close-modal" title="Close" class="modal-close" id="removeSupportingFileModalCloseBtn">Close</a>
 		<h3 id="removeSupportingFileModalTitle">Do you want to remove the file?</h3>
 		<div id="removeSupportingFileModalDesc">Supporting documents help us to assess your claim</div>
 		<div class="modal-buttons">
 			<button id="removeSupportingFileModalYesBtn" class="uikit-btn" onclick="window.location.href = '#'">Yes</button>
-			<button id="removeSupportingFileModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#'">No</button>
+			<button id="removeSupportingFileModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#close-modal'">No</button>
 		</div>
 	</div>
 </div>

--- a/views/auth/cover/partials/removefile-modal.ejs
+++ b/views/auth/cover/partials/removefile-modal.ejs
@@ -1,11 +1,11 @@
 <div role="dialog" aria-hidden="true" aria-labelledby="removeFileModalTitle" aria-describedby="removeFileModalDesc" id="open-removefile-modal" class="modal-window">
 	<div role="document">
-		<a href="#" title="Close" class="modal-close" id="removeFileModalCloseBtn">Close</a>
+		<a href="#close-modal" title="Close" class="modal-close" id="removeFileModalCloseBtn">Close</a>
 		<h3 id="removeFileModalTitle">Do you want to remove the file?</h3>
 		<div id="removeFileModalDesc">Medical documents help us to assess your claim.</div>
 		<div class="modal-buttons">
 			<button id="removeFileModalYesBtn" class="uikit-btn" onclick="window.location.href = '#'">Yes</button>
-			<button id="removeFileModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#'">No</button>
+			<button id="removeFileModalNoBtn" class="uikit-btn uikit-btn--tertiary" onclick="window.location.href = '#close-modal'">No</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
- Annoying spasm fixed (was caused by blank fragment defaulting to top of page. oops);
- Expanding on edge-case tab handling (eg: from browser GUI to page with modal open);
- Further cleanup of functions;
- Fixed tab looping bug involving going out of modal for split second.
- Placement of imported modal components now similarly placed like with the React code (also to support default return focus to minimise jarring scrolling when trigger is already in view)

Known issue:
- Edge case: focus in from browser address bar to page content when modal is open scrolls in background but handling is in place to restore focus to modal. (Unfortunately has a race condition where NVDA sometimes reads the modal contents, sometimes it doesn't in this scenario)