### PR TITLE
New media query added to ensure top panel height works across all mobile devices

### DIFF
--- a/src/sass/myservice-sliding-panel-top.scss
+++ b/src/sass/myservice-sliding-panel-top.scss
@@ -242,4 +242,15 @@
 	}
 }
 
+@media only screen and (min-width: 960px) and (max-width:991px) {
+	.accordion-toppanel--wrapper{
+		.uikit-accordion.accordion-open {
+			.uikit-accordion__body {
+				height:470px!important;
+				max-height:470px!important;
+			}
+		}
+	}
+}
+	
 }


### PR DESCRIPTION
@media only screen and (min-width: 960px) and (max-width:991px)