### PR TITLE
MYS-1383 css fix for logo header:

### DIFF
--- a/src/sass/myservice-header.scss
+++ b/src/sass/myservice-header.scss
@@ -16,6 +16,7 @@ header {
 		color: white;
 	}
 	.logo-myservice {
+		height: 100%; // needed for buggy IE SVG rendering
 		max-width: 200px;
 		padding: 1em 0 0 0;
 	}


### PR DESCRIPTION
- IE11 (Win7 and older) bug: SVG rendering incorrect default height where no height is supplied in CSS.