### PR TITLE
MYS-1376 inconsistent icon fix for message tip component:

### DIFF
--- a/src/sass/myservice-components.scss
+++ b/src/sass/myservice-components.scss
@@ -39,7 +39,7 @@
 	
 	border-left:4px solid $blue-60;
 	background: $blue-10 url(../images/ico-info-thin-blue.svg) no-repeat 1em 2.2em;
-	background-size: 35px;
+	background-size: 35px 35px; // explicit dimensions due to buggy SVG rendering in IE.
 	padding:2em 2em 2em 4em;
 	display:block;
 	margin-bottom: 1.5em;


### PR DESCRIPTION
- Explicitly defined second dimension for icon image size as IE's auto-sizing for preserving aspect ratio is buggy.