### PR TITLE
MYS-1451, MYS-1455, maybe MYS-1449: long text string style fix

### DIFF
--- a/src/sass/myservice-typography.scss
+++ b/src/sass/myservice-typography.scss
@@ -145,6 +145,7 @@ table.data-centred {
 	  font-size: 0.9rem;
 		text-align: center;
 		vertical-align: middle;
+		word-break: break-all;
 	}
 	td {
 	  padding: 0.5em 0.5em 0.5em 0.5em;

--- a/src/sass/myservice-widgets.scss
+++ b/src/sass/myservice-widgets.scss
@@ -100,6 +100,7 @@ table.table-claims {
 		padding: 0.75em 1em 0.75em 0.75em;
 		vertical-align: middle;
 		border-bottom:1px solid $gray-mild;
+		word-break: break-all
 	}
 	td {
 		padding: 0.75em 1em 0.75em 0.75em;


### PR DESCRIPTION
- added word-break: break-all style to account for possible unintended elongation of layout where long streams of text without whitespace appears.