### PR TITLE
Fix tool tips with very little content

### DIFF
--- a/src/sass/myservice-widgets.scss
+++ b/src/sass/myservice-widgets.scss
@@ -567,7 +567,7 @@
   background: $blue-10; // url("../images/ico-info-thin-blue.svg") no-repeat 1em 2.2em;
   border: 1px solid $blue-60;
   border-radius: 0.3em;
-  max-width: $uikit-maxwidth;
+  width: $uikit-maxwidth;
   opacity: 1;
   outline: medium none;
   box-shadow: rgba(0, 0, 0, 0.3) 0 2px 10px;


### PR DESCRIPTION
Fixed issue where content of tool tip was so small that it didn't overlap with the tab.