### PR TITLE
Added input-type number webkit appearance text as a quick fix for autoprefixer

### DIFF
--- a/src/sass/myservice-widgets.scss
+++ b/src/sass/myservice-widgets.scss
@@ -91,7 +91,6 @@
       @include uikit-media(sm) {
         max-width: 370px;
       }
-      flex-basis: 20%;
       min-width: 300px;
     }
   }
@@ -146,6 +145,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
+    width: 100%;
   }
 
   .fal {
@@ -590,11 +590,6 @@
 
 }
 
-// @media only screen and (min-width: $medium-tablet) {
-//   .widget-btn {
-//     margin: 0 0.5em 0 2em;
-//   }
-// }
 // Claims table on authenticated home page
 .table-claims {
   border: 1px solid $gray-mild;
@@ -648,7 +643,6 @@
 }
 
 .status-icon {
-  // background-position: -.25em 0;
   background-position-y: .2em;
   background-repeat: no-repeat;
   background-size: 26px 26px;


### PR DESCRIPTION
Autoprefixer added webkite appearance of textfield to input type of number above 576px.

This is intended to be a quick fix until the reason this bug occurred can be resolved.