### PR TITLE
moved mobile-hide class to the bottom of the file to avoid cascade issues

### DIFF
--- a/src/sass/myservice-widget-tiles.scss
+++ b/src/sass/myservice-widget-tiles.scss
@@ -40,10 +40,6 @@
   max-width: 100%;
 }
 
-.widget-tile--mobile-hide {
-  display: none;
-}
-
 .widget-tile span {
   //TODO Can we remove the default underline on spans in myservice-typography?
   border-bottom: 0;
@@ -487,4 +483,8 @@
 
 #widget-payment .widget-tile__content {
   flex-direction: column;
+}
+
+.widget-tile--mobile-hide {
+  display: none;
 }


### PR DESCRIPTION
The mobile hide class was not correctly being applied to the profile widget on the home page.
 
This bug occurred due to a cascade related issue in the CSS file, this class has been moved to below the .widget-ang-component class to ensure the mobile-hide class applies correctly.