### PR TITLE
added fa-fw class to the fa icons and margin to the fa-2x class

### DIFF
--- a/partials/components/layout/header-authenticated.ejs
+++ b/partials/components/layout/header-authenticated.ejs
@@ -31,8 +31,10 @@ locals.el.icons = ["fa-home","fa-list-alt","fa-calendar-check","fa-credit-card-b
           link += '">';
           %>
 
-      <li class="menu__item <%- external %>" id=<%- itemID %>><%- link %><div class="fal <%= locals.el.icons[index] %> fa-2x"></div>
-        <div class="menu__item-name"><%= element %></div></a>
+      <li class="menu__item <%- external %>" id=<%- itemID %>>
+        <%- link %>
+          <div class="fal <%= locals.el.icons[index] %> fa-2x fa-fw"></div><div class="menu__item-name"><%= element %></div>
+        </a>
       </li>
       <%});%>
     </ul>

--- a/src/sass/myservice-header.scss
+++ b/src/sass/myservice-header.scss
@@ -209,8 +209,7 @@ header {
 
     .fa-2x {
       font-size: 1.3em;
-      width: 1.3em;
-
+      margin-right: 8px;
       &::before {
         top: 5px;
       }


### PR DESCRIPTION
Font awesome icons do not have correct spacing in the angular app.

This fix is a new approach to ensure spacing is correct.

Tasks completed:
- Added new class fa-fw to center icons
- Removed width and added margin-right
- Removed white-space between fa icon and menu item in proto