### PR TITLE
class stops the dropdown from not being the correct width when a line is too long

### DIFF
--- a/src/sass/myservice-file-uploads.scss
+++ b/src/sass/myservice-file-uploads.scss
@@ -326,3 +326,8 @@ $gutter-size: 2em;
     right: 1em; 
   }
 }
+
+//fixes bug with document uploader not displaying correctly
+.pt-doc-type {
+  min-width: 237px;
+}


### PR DESCRIPTION
Added a min-width to the document upload dropdown.