### PR TITLE
added flex-basis: 20%  to flex-item as this is required for the card …

### DIFF
--- a/src/sass/myservice-widgets.scss
+++ b/src/sass/myservice-widgets.scss
@@ -95,6 +95,7 @@
       @include uikit-media(md) {
         max-width: 360px;
       }
+      flex-basis: 20%;
       min-width: 300px;
     }
   }


### PR DESCRIPTION
flex-basis: 20% is a required flex-box property for the service pension claim tiles. Adding this property ensures two tiles are displayed side-by-side on larger devices.