### PR TITLE
Moved display block for mobile-hide to below widget-ang-component

### DIFF
--- a/src/sass/myservice-widget-tiles.scss
+++ b/src/sass/myservice-widget-tiles.scss
@@ -365,10 +365,6 @@
 }
 
 @media only screen and (min-width: $AU-media-lg) {
-  .widget-tile--mobile-hide {
-    display: block;
-  }
-
   .intro {
     .flex-container {
       padding: 0px !important;
@@ -487,5 +483,8 @@
 }
 
 .widget-tile--mobile-hide {
+  @include uikit-media(sm) {
+    display: block;
+  }
   display: none;
 }


### PR DESCRIPTION
Moved display block to below the widget-ang-component class to avoid cascade related issues.