### PR TITLE
disabled autofill on the address form

### DIFF
--- a/views/unauth/registration/register-7.ejs
+++ b/views/unauth/registration/register-7.ejs
@@ -69,6 +69,11 @@
     $('.btnNext').click(function () {
       location.href = '/unauth/registration/register-3';
     });
+
+    //adding autocomplete attr to form elements
+    var allInputs = $(":input");
+    allInputs.attr("autocomplete", "new-password");
+    console.log(allInputs);
   </script>
 </body>
 


### PR DESCRIPTION
Link for reference:
/unauth/registration/register-7

We can disable the autofill by adding 'autocomplete=new-password' to inputs we do not wish the autocomplete to work for. This can be added to individual inputs or the entire form.