### PR TITLE
Update desktop header to use flexbox

### DIFF
--- a/src/sass/myservice-header.scss
+++ b/src/sass/myservice-header.scss
@@ -233,18 +233,17 @@ header {
     .menu {
       background-color: transparent;
       box-shadow: none;
-      display: block;
+      display: flex;
       margin: 0;
       // max-height: 5.8em;
       padding: 0;
       position: relative;
       text-align: right;
       width: auto;
-
     }
 
     .menu__item {
-      display: inline-block;
+      margin-left: 4px;
     }
 
     .menu__item-link {
@@ -449,7 +448,7 @@ header {
 @media (max-width: $AU-media-sm) {
   .secondary-navigation {
     display: none;
-}
+  }
 }
 
 
@@ -494,9 +493,6 @@ header {
     @media screen and (min-width: 992px) {
       width: 100%;
       max-width: 250px;
-    }
-    .logo-myservice {
-      max-width: 200px;
     }
   }
 

--- a/src/sass/myservice-header.scss
+++ b/src/sass/myservice-header.scss
@@ -80,7 +80,6 @@ header {
     // min-height: 6em;
 
     .logo-myservice {
-      float: left;
       padding: 1.9em 0 0;
     }
 
@@ -235,7 +234,6 @@ header {
       background-color: transparent;
       box-shadow: none;
       display: block;
-      float: right;
       margin: 0;
       // max-height: 5.8em;
       padding: 0;
@@ -460,6 +458,10 @@ header {
   background: #164d97;
   @media screen and (min-width: 991px) {
     background-image: url(../images/bg-header-auth.jpg);
+
+    #mys-logo {
+      display: block;
+    }
   }
 
   .mys-header__container {
@@ -467,8 +469,9 @@ header {
     margin: auto;
     @media screen and (min-width: 992px) {
       width: 968px;
-      min-height: 5.79em;
       max-width: 100%;
+      display: flex;
+      justify-content: space-between;
     }
 
     @media screen and (min-width: 1200px) {
@@ -487,13 +490,14 @@ header {
 
   .logo-myservice {
     max-width: 190px;
+
     @media screen and (min-width: 992px) {
+      width: 100%;
       max-width: 250px;
     }
-        .logo-myservice {
+    .logo-myservice {
       max-width: 200px;
     }
-
   }
 
   .is-active {

--- a/src/sass/myservice-header.scss
+++ b/src/sass/myservice-header.scss
@@ -243,7 +243,7 @@ header {
     }
 
     .menu__item {
-      margin-left: 4px;
+      margin-left: 0.25em;
     }
 
     .menu__item-link {


### PR DESCRIPTION
Remove floats for the logo / menu and the arbitrary header height and replace with flexbox to better wrap the contents of the header. 

* Fixes an issue on MyService where the header height differs slightly to proto due to the icon implementation.