### PR TITLE
Cards - fix print css #2

### DIFF
--- a/src/sass/mys-cards.scss
+++ b/src/sass/mys-cards.scss
@@ -130,7 +130,7 @@ ul, ol, dl  { page-break-before:avoid }
 
   .health-card__extras {
     border-top: 0 !important;
-    display: flex;
+    display: flex !important;
   }
 
   .health-card__image-container {


### PR DESCRIPTION
Use !important to override display: none.