### PR TITLE
Accessibility - cards

### DIFF
--- a/src/sass/mys-cards.scss
+++ b/src/sass/mys-cards.scss
@@ -13,8 +13,9 @@
 }
 
 .print-button {
-  color: $blue-mid;
-
+  color: $blue-mid !important;
+  border-bottom: 0 !important;
+  
   .icon {
     margin-right: 5px;
   }
@@ -23,12 +24,11 @@
     text-decoration: underline;
   }
 
-  &:hover {
-    background: #5BCBE3;
+  &:hover, &:focus {
+    color: $uikit-colour-Text !important;
   }
 
-  cursor      : pointer;
-  margin-right: 10px;
+  margin-right: 10px !important;
 }
 
 .cards__wrapper {

--- a/src/sass/myservice-healthcards.scss
+++ b/src/sass/myservice-healthcards.scss
@@ -46,6 +46,10 @@
     text-decoration: underline;
     border-bottom  : none;
     font-size      : 1.062em;
+
+    &:hover, &:focus {
+      color: $uikit-colour-Text !important;
+    }    
   }
 }
 
@@ -180,7 +184,6 @@
   background                : none;
   border                    : none;
   color                     : $blue-mid;
-  outline                   : none;
   width                     : auto;
   height                    : auto;
   display                   : flex;
@@ -286,7 +289,7 @@
 .health-card__conditions-list {
   display       : flex;
   border        : 1px solid lightgray;
-  border-radius : 1%;
+  border-radius : 5px;
   flex-direction: column;
   background    : $white;
 }

--- a/views/auth/profile/cards/index.ejs
+++ b/views/auth/profile/cards/index.ejs
@@ -33,10 +33,10 @@
             </div> 
             <div class="cards-header margin-below--mid">
               <h1 class="mys h1 margin-above--none margin-below--none">Cards</h1>
-              <div class="print-button">
+              <button class="uikit-btn uikit-btn--borderless print-button" onClick="window.print(); return false">
                 <span class="icon far fa-print"></span>
                 <span class="label">Print this page</span>
-              </div>
+              </button>
             </div>
             <!-- card white -->
             <div class="health-card toggled-open" id="veteran-white">


### PR DESCRIPTION
* Fixed hover contrast for the 'Print this page' link.
* Fixed hover contrast for the 'Order replacement' link.
* Made 'Print this page' and 'Show details' links focusable by tabbing.
* Changed the border-radius on the conditions box to pixels to prevent the radius stretching vertically.