### PR TITLE
Hide native radio input control

### DIFF
--- a/src/sass/myservice-forms.scss
+++ b/src/sass/myservice-forms.scss
@@ -1305,6 +1305,10 @@ label {
   }
 }
 
+.uikit-control-input__input {
+  opacity: 0; // Hide native control to prevent it from becoming visible on zoom out
+}
+
 .custom_disabled--checkbox {
   .uikit-control-input__input {
     &:disabled {


### PR DESCRIPTION
Updates the radio input element to make it invisible while retaining accessibility to prevent it appearing when zooming out in Firefox.